### PR TITLE
Add functional test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ install:
 
 script:
   - PYTHONPATH=. trial tests
+  - python -m unittest discover tests/functional

--- a/prism/protocol/client.py
+++ b/prism/protocol/client.py
@@ -40,11 +40,11 @@ class BlobReflectorClient(Protocol):
             d.addErrback(self.response_failure_handler)
 
     def connectionLost(self, reason):
+        self.factory.on_connection_lost_d.callback(None)
         if reason.check(error.ConnectionDone):
             log.debug('Reflector finished: %s', reason)
         else:
             raise reason
-        reactor.fireSystemEvent("shutdown")
 
     # IConsumer stuff
     def registerProducer(self, producer, streaming):

--- a/prism/protocol/factory.py
+++ b/prism/protocol/factory.py
@@ -39,7 +39,7 @@ class PrismServerFactory(ServerFactory):
             log.warning("%i blobs need to be sent from previous run", len(blobs))
             log.warning("queueing %i of them to be sent", len(blobs))
             for i, blob_hash in enumerate(blobs):
-                enqueue_blob(blob_hash, self.client_factory)
+                enqueue_blob(blob_hash, self.storage, self.client_factory)
             log.info("queued blobs, starting server")
 
 

--- a/prism/protocol/factory.py
+++ b/prism/protocol/factory.py
@@ -8,8 +8,6 @@ from prism.config import get_settings
 
 log = logging.getLogger(__name__)
 settings = get_settings()
-BLOB_DIR = os.path.expandvars(settings['blob directory'])
-
 
 class PrismServerFactory(ServerFactory):
     """
@@ -34,7 +32,7 @@ class PrismServerFactory(ServerFactory):
         return p
 
     def startFactory(self):
-        blobs = os.listdir(BLOB_DIR)
+        blobs = os.listdir(self.storage.db_dir)
         if blobs:
             log.warning("%i blobs need to be sent from previous run", len(blobs))
             log.warning("queueing %i of them to be sent", len(blobs))

--- a/prism/protocol/factory.py
+++ b/prism/protocol/factory.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from twisted.internet.protocol import ServerFactory, ClientFactory
+from twisted.internet import defer
 
 from prism.protocol.server import ReflectorServerProtocol, enqueue_blob
 from prism.protocol.client import BlobReflectorClient
@@ -50,6 +51,10 @@ class PrismClientFactory(ClientFactory):
         self.protocol_version = 1
         self.sent_blobs = False
         self.p = None
+        #this deferred is fired when this protocol is disconnected
+        #(when connectionLost() is called)
+        self.on_connection_lost_d = defer.Deferred()
+
 
     def buildProtocol(self, addr):
         p = self.protocol()

--- a/prism/protocol/server.py
+++ b/prism/protocol/server.py
@@ -77,7 +77,7 @@ class ReflectorServerProtocol(Protocol):
         yield self.close_blob()
         yield self.send_response({response_key: True})
         log.info("Received %s from %s", blob, self.peer.host)
-        enqueue_blob(blob_hash, self.client_factory)
+        enqueue_blob(blob_hash, self.blob_storage, self.client_factory)
 
     @defer.inlineCallbacks
     def _on_failed_blob(self, err, response_key):

--- a/prism/protocol/server.py
+++ b/prism/protocol/server.py
@@ -77,7 +77,7 @@ class ReflectorServerProtocol(Protocol):
         yield self.close_blob()
         yield self.send_response({response_key: True})
         log.info("Received %s from %s", blob, self.peer.host)
-        enqueue_blob(blob_hash, self.blob_storage, self.client_factory)
+        enqueue_blob(blob_hash, self.blob_storage.db_dir, self.client_factory)
 
     @defer.inlineCallbacks
     def _on_failed_blob(self, err, response_key):

--- a/prism/protocol/task.py
+++ b/prism/protocol/task.py
@@ -48,14 +48,14 @@ def next_host():
         return address, int(port), blob_count
 
 
-def process_blob(blob_hash, client_factory_class):
+def process_blob(blob_hash, blob_storage, client_factory_class):
     log.debug("process blob pid %s", os.getpid())
-    blob_path = os.path.join(BLOB_DIR, blob_hash)
+    blob_path = os.path.join(blob_storage.db_dir, blob_hash)
     if not os.path.isfile(blob_path):
         log.warning("%s does not exist", blob_path)
         return sys.exit(0)
     host, port, host_blob_count = next_host()
-    factory = client_factory_class(ClusterStorage(BLOB_DIR), [blob_hash])
+    factory = client_factory_class(blob_storage, [blob_hash])
     try:
         from twisted.internet import reactor
         reactor.connectTCP(host, port, factory)
@@ -78,6 +78,6 @@ def process_blob(blob_hash, client_factory_class):
 
 
 @retry_redis
-def enqueue_blob(blob_hash, client_factory_class):
+def enqueue_blob(blob_hash, blob_storage, client_factory_class):
     q = Queue(connection=redis_conn)
-    q.enqueue(process_blob, blob_hash, client_factory_class, timeout=60)
+    q.enqueue(process_blob, blob_hash, blob_storage, client_factory_class, timeout=60)

--- a/prism/protocol/task.py
+++ b/prism/protocol/task.py
@@ -48,9 +48,13 @@ def next_host():
         return address, int(port), blob_count
 
 
+def get_blob_path(blob_hash, blob_storage):
+    return os.path.join(blob_storage.db_dir, blob_hash)
+
+
 def process_blob(blob_hash, blob_storage, client_factory_class):
     log.debug("process blob pid %s", os.getpid())
-    blob_path = os.path.join(blob_storage.db_dir, blob_hash)
+    blob_path = get_blob_path(blob_hash, blob_storage)
     if not os.path.isfile(blob_path):
         log.warning("%s does not exist", blob_path)
         return sys.exit(0)

--- a/prism/protocol/task.py
+++ b/prism/protocol/task.py
@@ -52,13 +52,13 @@ def get_blob_path(blob_hash, blob_storage):
     return os.path.join(blob_storage.db_dir, blob_hash)
 
 
-def process_blob(blob_hash, blob_storage, client_factory_class):
+def process_blob(blob_hash, blob_storage, client_factory_class, host_getter=next_host):
     log.debug("process blob pid %s", os.getpid())
     blob_path = get_blob_path(blob_hash, blob_storage)
     if not os.path.isfile(blob_path):
         log.warning("%s does not exist", blob_path)
         return sys.exit(0)
-    host, port, host_blob_count = next_host()
+    host, port, host_blob_count = host_getter()
     factory = client_factory_class(blob_storage, [blob_hash])
     try:
         from twisted.internet import reactor

--- a/prism/storage/storage.py
+++ b/prism/storage/storage.py
@@ -73,6 +73,11 @@ class ClusterStorage(object):
         defer.returnValue(sent_to_host)
 
     @defer.inlineCallbacks
+    def add_blob_to_host(self, blob_hash, host):
+        out = yield self.db.sadd(host, blob_hash)
+        out = yield self.db.sadd(CLUSTER_BLOBS, blob_hash)
+
+    @defer.inlineCallbacks
     def get_needed_blobs_for_stream(self, sd_hash):
         """
         Return a list of known_needed_blobs

--- a/tests/functional/test_task.py
+++ b/tests/functional/test_task.py
@@ -1,0 +1,132 @@
+from prism.protocol.task import  process_blob, get_blob_path
+from prism.protocol.factory import PrismClientFactory, PrismServerFactory
+from prism.storage.storage import ClusterStorage
+from prism.protocol.blob import BlobFile
+from twisted.internet import defer, task
+
+import unittest
+import shutil
+import tempfile
+import fakeredis
+import os
+import time
+import multiprocessing
+import threading
+import Queue
+
+BLOB_HASH= '0aceb607d62e5c75468ded32343a2812d69e0f4545c9fd471f2e1f96f0b6769fda58584a88e9c96778372916b9062b0f'
+BLOB_CONTENT = "#z{5\xc1\x11U\xb8\xeb'%>\x9b\xa9@\x02\xf4\x8c\xba\x01\xc0\xce\x11\xc2\xb4\xd8\xb5MOo\xcfE"
+
+def get_redis():
+    import fakeredis
+    return fakeredis.FakeRedis()
+
+def _setup_server(server_queue, client_queue):
+    """
+    We setup server for receiving blobs here on a process,
+    so we can utilize a seperate reactor, and a
+    seperate fakeredis instances
+    """
+    from twisted.internet import reactor
+    def _listen_queue():
+        # listen for the client to give a stop signal
+        # (so that we know we are done)
+        try:
+            obj = server_queue.get(block=False,timeout=0)
+        except Queue.Empty as e:
+            pass
+        else:
+            if obj == 'stop':
+                reactor.stop()
+
+    @defer.inlineCallbacks
+    def on_finish():
+        # put results of things we want to test on the client queue
+        # so that it can test using self.assert....
+        blob_exists =  yield server_storage.blob_exists(BLOB_HASH)
+        blob_content = None
+        with open(os.path.join(server_db_dir, BLOB_HASH),'r') as blob_file:
+            blob_content = blob_file.read()
+        client_queue.put({'blob_content':blob_content,'blob_exists':blob_exists})
+
+    server_db_dir = tempfile.mkdtemp()
+    server_storage = ClusterStorage(server_db_dir)
+    server_storage.db.db = get_redis()
+    server_factory = PrismServerFactory(server_storage)
+    port = reactor.listenTCP(5566, server_factory)
+    loop = task.LoopingCall(_listen_queue)
+    loop.start(0.01)
+
+    reactor.addSystemEventTrigger('before','shutdown', on_finish)
+    reactor.run()
+
+    shutil.rmtree(server_db_dir)
+
+
+class TestTask(unittest.TestCase):
+
+    def _setup_server(self):
+        # this is where server will receive from client
+        self.server_queue = multiprocessing.Queue()
+        # this is where client will receive from server
+        self.client_queue = multiprocessing.Queue()
+        self.server_process = multiprocessing.Process(target=_setup_server,
+            args=(self.server_queue, self.client_queue))
+        self.server_process.start()
+
+    def tearDown(self):
+        shutil.rmtree(self.client_db_dir)
+
+    @defer.inlineCallbacks
+    def _setup_client(self):
+        # setup client storage
+        self.client_db_dir = tempfile.mkdtemp()
+        self.client_storage = ClusterStorage(self.client_db_dir)
+        self.client_storage.db.db = get_redis()
+
+         # create blob to send on client
+        blob_file = BlobFile(self.client_db_dir, BLOB_HASH, len(BLOB_CONTENT))
+        finished_d, write, _ = blob_file.open_for_writing(None)
+        write(BLOB_CONTENT)
+        yield finished_d
+        yield self.client_storage.completed(BLOB_HASH, len(BLOB_CONTENT))
+
+    @defer.inlineCallbacks
+    def _on_finish(self):
+        # check client storage state after protocol is finished
+        # sometimes this hangs and takes a longer time than expected (about 10 to 20 seconds..)
+        # not sure why...
+        self.blob_exists = yield self.client_storage.blob_exists(BLOB_HASH)
+        self.blob_has_been_forwarded = yield self.client_storage.blob_has_been_forwarded_to_host(BLOB_HASH)
+
+    def test_process_blob(self):
+        self._setup_server()
+        self._setup_client()
+
+        client_factory_class = PrismClientFactory
+        expected_file_path = get_blob_path(BLOB_HASH, self.client_storage)
+        self.assertTrue(os.path.isfile(expected_file_path))
+
+        # start client
+        from twisted.internet import reactor
+        reactor.addSystemEventTrigger('before','shutdown', self._on_finish)
+        try:
+            process_blob(BLOB_HASH, self.client_db_dir, client_factory_class, 'fake', host_infos=('localhost',5566,0))
+        except SystemExit:
+            pass
+
+        # tell server process to stop
+        self.server_queue.put('stop')
+
+        # check client variables
+        self.assertEqual(1, self.blob_exists)
+        self.assertEqual(1, self.blob_has_been_forwarded)
+        # file should be removed from client, because it was sent to server
+        self.assertFalse(os.path.isfile(expected_file_path))
+
+        # check expected variables we should received from server
+        server_results = self.client_queue.get()
+        self.assertEqual(BLOB_CONTENT, server_results['blob_content'])
+        self.assertEqual(1, server_results['blob_exists'])
+
+


### PR DESCRIPTION
Added functional test that sets up a prism client protocol for sending blobs, and a prism server protocol for receiving blobs. Have them transfer a blob between each other. 

(note that this test is slightly different from what we actually want to test which is prism sending blobs to a reflector protocol in lbrynet, and prism receiving blobs from a  reflector protocol in lbrynet. However, since we will be moving to unify the reflector protocol in lbrynet with the protocol in prism, this test will test exactly what we need in the future) 

Most of the changes are for making process_blob() and enqueue_blob() in task.py take more arguments so that they can be tested. The commits should be self explanatory except here is some note on the largest commit below : https://github.com/lbryio/reflector-cluster/pull/5/commits/e52f4f344abef91f94b16f7a9d98176580748c63

In the previous process_blob() we had some crucial code that was supposed to run after reactor.run() , which updates the redis server and deletes the sent blob from the file system. This code would get triggered because client protocol calls reactor.fireSystemEvent('shutdown').  Having the client protocol calling the shutdown is problematic because in the testing, we need to attach callback tests after when the client protocol is finished and these won't get run if we are shutting down. Also if we update the redis server after reactor.run() we can't use the ClusterStorage class because those rely on the reactor. 

The better twisted approach is for client protocol to fire a deferred indicating when its done, and the process_blob() function adding callbacks to the deferred.  The process_blob() will also be responsible for calling reactor.fireSystemEvent('shutdown') and this is more logical since process_blob() is also responsible for starting the reactor. 




