### PR TITLE
close_read_handle() no longer supported on lbrynet 0.17.0rc8

### DIFF
--- a/prism/protocol/client.py
+++ b/prism/protocol/client.py
@@ -85,7 +85,7 @@ class BlobReflectorClient(Protocol):
 
     def set_not_uploading(self):
         if self.next_blob_to_send is not None:
-            self.next_blob_to_send.close_read_handle(self.read_handle)
+            self.read_handle.close()
             self.read_handle = None
             self.next_blob_to_send = None
         self.file_sender = None

--- a/prism/protocol/stream_client.py
+++ b/prism/protocol/stream_client.py
@@ -95,7 +95,7 @@ class StreamReflectorClient(Protocol):
 
     def set_not_uploading(self):
         if self.next_blob_to_send is not None:
-            self.next_blob_to_send.close_read_handle(self.read_handle)
+            self.read_handle.close()
             self.read_handle = None
             self.next_blob_to_send = None
         self.file_sender = None

--- a/prism/storage/storage.py
+++ b/prism/storage/storage.py
@@ -232,8 +232,9 @@ class ClusterStorage(object):
 
     @defer.inlineCallbacks
     def load_sd_blob(self, sd_blob):
-        with sd_blob.open_for_reading() as sd_file:
-            sd_blob_data = sd_file.read()
+        sd_file = sd_blob.open_for_reading()
+        sd_blob_data = sd_file.read()
+        sd_file.close()
         decoded_sd_blob = json.loads(sd_blob_data)
         blob_hashes = []
         for blob in decoded_sd_blob['blobs']:


### PR DESCRIPTION
When we update lbrynet on prism cluster 3 to 0.17.0rc8, this patch is required