### PR TITLE
No longer need to import or initialize lbrynet conf

### DIFF
--- a/prism/storage/storage.py
+++ b/prism/storage/storage.py
@@ -6,8 +6,6 @@ from redis import Redis
 
 from lbrynet.blob.blob_file import BlobFile
 from lbrynet.core.utils import is_valid_blobhash
-from lbrynet import conf
-conf.initialize_settings() #needed since BlobFile needs nconf
 
 from twisted.internet import defer, threads
 


### PR DESCRIPTION
Since blob_file on longer relies on lbrynet conf, remove it. 
Can be merged when https://github.com/lbryio/lbry/pull/931 is merged 