### PR TITLE
Add timeouts

### DIFF
--- a/prism/protocol/server.py
+++ b/prism/protocol/server.py
@@ -61,7 +61,7 @@ class ReflectorServerProtocol(Protocol, TimeoutMixin):
 
     def connectionLost(self, reason=failure.Failure(error.ConnectionDone())):
         self.setTimeout(None)
-        log.debug("upload from %s finished", self.peer.host)
+        log.info("Connection lost to %s: %s", self.peer.host, reason)
 
     def handle_error(self, err):
         log.error(err.getTraceback())

--- a/prism/protocol/stream_client.py
+++ b/prism/protocol/stream_client.py
@@ -57,9 +57,9 @@ class StreamReflectorClient(Protocol, TimeoutMixin):
 
     def connectionLost(self, reason):
         self.setTimeout(None)
+        log.info('Connection lost: %s', reason)
         if reason.check(error.ConnectionDone):
             self.factory.on_connection_lost_d.callback(None)
-            log.debug('Reflector finished: %s', reason)
         else:
             self.factory.on_connection_lost_d.errback(reason)
             raise reason


### PR DESCRIPTION
I believe that prism-workers are hanging in a busy state for a long time due to a lack of timeouts in the server and client protocols. I added the timeouts using twisted's TimeoutMixi.

Not sure what causes these timeouts but this fix seems to keep the prism-workers from getting stuck.
