### PR TITLE
swap vulnerable dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Twisted==16.6.0
-pycryptodome==3.6.4
 rq==0.8.0
 pyyaml==3.12
 psutil==5.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Twisted==16.6.0
-pycrypto==2.6.1
+pycryptodome==3.6.4
 rq==0.8.0
 pyyaml==3.12
 psutil==5.2.2

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from prism import __version__
 
 requires = [
     'twisted==16.6.0',
-    'pycrypto==2.6.1',
+    'pycryptodome==3.6.4',
     'rq==0.8.0',
     'pyyaml==3.12',
     'psutil==5.2.2',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ from prism import __version__
 
 requires = [
     'twisted==16.6.0',
-    'pycryptodome==3.6.4',
     'rq==0.8.0',
     'pyyaml==3.12',
     'psutil==5.2.2',


### PR DESCRIPTION
For what it's worth, this PR swaps the old pycrypto lib with the new "almost-drop-in" library replacement: https://github.com/Legrandin/pycryptodome#pycryptodome